### PR TITLE
Change default namespace for Menu project

### DIFF
--- a/Menu/Menu.csproj
+++ b/Menu/Menu.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>DinoDiner.Menu</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add `DinoDiner.` to the default namespace for the `Menu` Project to match the namespace of the already generated files.