### PR TITLE
New test changes

### DIFF
--- a/MenuTest/MenuItemNamesTest.cs
+++ b/MenuTest/MenuItemNamesTest.cs
@@ -23,7 +23,7 @@ namespace MenuTest
         {
 
             DinoNuggets dn = new DinoNuggets();
-            Assert.Equal("Dino-Nuggets", dn.ToString());
+            Assert.Equal("Dino Nuggets", dn.ToString());
         }
 
 
@@ -74,7 +74,7 @@ namespace MenuTest
         {
             Fryceritops ft = new Fryceritops();
             ft.Size = size;
-            Assert.Equal($"{size} Friceritops", ft.ToString());
+            Assert.Equal($"{size} Fryceritops", ft.ToString());
         }
 
         [Theory]


### PR DESCRIPTION
Fryceritops has been spelled with a y, demonstrated by the class name. Having a dash in Dino Nuggets is somewhat silly.